### PR TITLE
graphviz.js: Don't require the 'sys' module.

### DIFF
--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -1,8 +1,7 @@
 /**
  * Module dependencies.
  */
-var sys = require('sys'),
-  path = require('path'),
+var path = require('path'),
   spawn  = require('child_process').spawn,
   temp = require('temp'),
   fs = require('fs'),


### PR DESCRIPTION
It's not used and it causes a deprecation warning with node.js 0.6 because the module has been renamed to 'util'.
