### PR TITLE
close temp file in write callback

### DIFF
--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -74,9 +74,14 @@ exports.parse = function(file_or_script, callback, errback) {
     _parse(file_or_script, callback, errback);
   } else {
     temp.open('node-graphviz', function(err, info) {
-      fs.write(info.fd, file_or_script);
-      fs.close(info.fd, function(err) {
-        _parse(info.path, callback, errback);
+      fs.write(info.fd, file_or_script, null, null, function(err, bytes) {
+        fs.close(info.fd, function(err) {
+          if (err) { 
+            errback(err); 
+          } else {
+            _parse(info.path, callback, errback);
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
I was having an issue where, when generating many graphs, I was getting fs errors. Moving the close and parse into the write callback seems to have made the errors go away. I assume there was a race condition where the file was sometimes being closed before the write was complete.
