### PR TITLE
add hasOwnProperty to avoid deep-dredge

### DIFF
--- a/lib/deps/attributs.js
+++ b/lib/deps/attributs.js
@@ -241,7 +241,7 @@ Attributs.prototype.to_dot = function(link) {
   
   if(this.attributs.length > 0) {
     attrsOutput = attrsOutput + " [ ";
-    for(var name in this.attributs.items) {
+    for(var name in this.attributs.items) if(this.attributs.items.hasOwnProperty(name)) {
       if (this.attributs.items.hasOwnProperty(name)) {
         attrsOutput = attrsOutput + sep + name + " =" + quoteMe(name, this.attributs.items[name]);
         sep = ", ";

--- a/lib/deps/core_ext/hash.js
+++ b/lib/deps/core_ext/hash.js
@@ -45,7 +45,7 @@ Hash.prototype.hasItem = function(in_key) {
 }
 
 Hash.prototype.clear = function() {
-  for (var i in this.items) {
+  for (var i in this.items) if(this.items.hasOwnProperty(i)) {
     delete this.items[i];
   }
 

--- a/lib/deps/graph.js
+++ b/lib/deps/graph.js
@@ -47,7 +47,7 @@ var Graph = exports.Graph = function(graph, id) {
 Graph.prototype.addNode = function(id, attrs) {
   this.nodes.setItem(id, new Node(this, id));
   if( attrs ) {
-    for( k in attrs ) {
+    for( k in attrs ) if(attrs.hasOwnProperty(k)){
       this.nodes.items[id].set( k, attrs[k] );
     }
   }
@@ -110,7 +110,7 @@ Graph.prototype.addEdge = function(nodeOne, nodeTwo, attrs) {
   
   var edge = new Edge(this, _nodeOne, _nodeTwo);
   if( attrs ) {
-    for( k in attrs ) {
+    for( k in attrs ) if (attrs.hasOwnProperty(k)) {
       edge.set( k, attrs[k] );
     }
   }
@@ -260,21 +260,21 @@ Graph.prototype.to_dot = function() {
   }
   
   // Each clusters
-  for( var id in this.clusters.items ) {
+  for( var id in this.clusters.items ) if(this.clusters.items.hasOwnProperty(id)){
     if (this.clusters.items.hasOwnProperty(id)) {
       dotScript = dotScript + this.clusters.items[id].to_dot() + '\n';
     }
   }
   
   // Each nodes
-  for( var id in this.nodes.items ) {
+  for( var id in this.nodes.items ) if(this.nodes.items.hasOwnProperty(id)) {
     if (this.nodes.items.hasOwnProperty(id)) {
       dotScript = dotScript + '  ' + this.nodes.items[id].to_dot() + ';\n'
     }
   }
   
   // Each edges
-  for( var i in this.edges ) {
+  for( var i in this.edges ) if(this.edges.hasOwnProperty(i)) {
     if (this.edges.hasOwnProperty(i)) {
       dotScript = dotScript + '  ' + this.edges[i].to_dot() + ';\n'
     }
@@ -317,7 +317,7 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
 		
 		// Get extra Graph Options
 		if( type_or_options.G != undefined ) {
-			for( attr in type_or_options.G ) {
+			for( attr in type_or_options.G ) if(type_or_options.G.hasOwnProperty(attr)){
 				if( gvattrs.isValid( attr, "G" ) == false ) {
 					util.debug( "Warning : Invalid attribut `"+attr+"' for a graph" );
 				}
@@ -326,7 +326,7 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
 		}
 		// Get extra Node Options
 		if( type_or_options.N != undefined ) {
-			for( attr in type_or_options.N ) {
+			for( attr in type_or_options.N ) if(type_or_options.N.hasOwnProperty(attr)){
 				if( gvattrs.isValid( attr, "N" ) == false ) {
 					util.debug( "Warning : Invalid attribut `"+attr+"' for a node" );
 				}
@@ -335,7 +335,7 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
 		}
 		// Get extra Edge Options
 		if( type_or_options.E != undefined ) {
-			for( attr in type_or_options.E ) {
+			for( attr in type_or_options.E ) if(type_or_options.E.hasOwnProperty(attr)){
 				if( gvattrs.isValid( attr, "E" ) == false ) {
 					util.debug( "Warning : Invalid attribut `"+attr+"' for an edge" );
 				}


### PR DESCRIPTION
Adding

    object.hasOwnProperty(key) 

Condition on each ```for( in )``` loop.

Following JavaScript best practices (see for example https://gist.github.com/aaronshaf/5663660 Deep members must be explicitly filtered (obj.hasOwnProperty(prop)) )