### PR TITLE
Long .dot strings are now supported

### DIFF
--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -35,7 +35,6 @@ exports.digraph = function(id) {
 };
 
 function _parse(file, callback, errback) {
-  console.log("Parsing!")
   var gvprScript = path.join(__dirname, "ext", "gvpr", "dot2js.g"),
     parameters = ["-f" + gvprScript, file],
     cmd = "gvpr",

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -59,8 +59,9 @@ function _parse(file, callback, errback) {
     } else {
       eval(out.toString());
       if (typeof __graph_eval == "undefined") {
-        console.log("__graph_eval is not defined in call to graphviz")
-        errback(0, out, "__graph_eval is not defined in call to graphviz")
+        if(errback) {
+          errback(code, out, "__graph_eval is not defined in call to graphviz")
+        }
       }
       else {
         callback(__graph_eval);
@@ -82,9 +83,7 @@ exports.parse = function(file_or_script, callback, errback) {
   } else {
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
-        if (err) console.log(err);
         fs.close(info.fd, function(err2) {
-          if (err2) console.log(err2);
           _parse(info.path, callback, errback);
         });
       });

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -74,9 +74,10 @@ exports.parse = function(file_or_script, callback, errback) {
     _parse(file_or_script, callback, errback);
   } else {
     temp.open('node-graphviz', function(err, info) {
-      fs.write(info.fd, file_or_script);
-      fs.close(info.fd, function(err) {
-        _parse(info.path, callback, errback);
+      fs.write(info.fd, file_or_script, function(err, written, string) {
+        fs.close(info.fd, function(err) {
+          _parse(info.path, callback, errback);
+        });
       });
     });
   }

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -72,8 +72,10 @@ function _parse(file, callback, errback) {
  */
 exports.parse = function(file_or_script, callback, errback) {
   if(fsExt.exist(file_or_script)) {
+    console.log("HERE FUCKER A");
     _parse(file_or_script, callback, errback);
   } else {
+    console.log("HERE FUCKER B");
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
         if (err) console.log(err);

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -57,7 +57,7 @@ function _parse(file, callback, errback) {
         errback(code, out, err); 
       }
     } else {
-      console.log("All data: " + data);
+      console.log("All data: " + out);
       eval(data.toString());
       callback(__graph_eval);
     }

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -53,6 +53,7 @@ function _parse(file, callback, errback) {
   });
   graphviz.stdin.end();
   graphviz.on('exit', function(code) {
+    console.log("Ending ");
     if(code !== 0 || __graph_eval === undefined) {
       if(errback) { 
         errback(code, out, err); 

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -54,14 +54,20 @@ function _parse(file, callback, errback) {
   graphviz.stdin.end();
   graphviz.on('exit', function(code) {
     console.log("Ending ");
-    if(code !== 0 || __graph_eval === undefined) {
+    if(code !== 0) {
       if(errback) { 
         errback(code, out, err); 
       }
     } else {
       console.log("All data: " + out);
       eval(out.toString());
-      callback(__graph_eval);
+      if (typeof __graph_eval == "undefined") {
+        console.log("__graph_eval is not defined in call to graphviz")
+        errback(0, out, "__graph_eval is not defined in call to graphviz")
+      }
+      else {
+        callback(__graph_eval);
+      }
     }
   });
 }

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -75,6 +75,7 @@ exports.parse = function(file_or_script, callback, errback) {
   } else {
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
+        console.log("Written: " + written + " " + string);
         fs.close(info.fd, function(err) {
           _parse(info.path, callback, errback);
         });

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -58,7 +58,7 @@ function _parse(file, callback, errback) {
       }
     } else {
       console.log("All data: " + out);
-      eval(data.toString());
+      eval(out.toString());
       callback(__graph_eval);
     }
   });

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -35,6 +35,7 @@ exports.digraph = function(id) {
 };
 
 function _parse(file, callback, errback) {
+  console.log("Parsing!")
   var gvprScript = path.join(__dirname, "ext", "gvpr", "dot2js.g"),
     parameters = ["-f" + gvprScript, file],
     cmd = "gvpr",
@@ -75,8 +76,10 @@ exports.parse = function(file_or_script, callback, errback) {
   } else {
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
+        if (err) console.log(err);
         console.log("Written: " + written + " " + string);
-        fs.close(info.fd, function(err) {
+        fs.close(info.fd, function(err2) {
+          if (err2) console.log(err2);
           _parse(info.path, callback, errback);
         });
       });

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -45,6 +45,7 @@ function _parse(file, callback, errback) {
     graphviz = spawn(cmd, parameters);
 
   graphviz.stdout.on('data', function(data) {
+    console.log("Incoming: " + data);
     out += data;
   });
   graphviz.stderr.on('data', function(data) {

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -45,7 +45,6 @@ function _parse(file, callback, errback) {
     graphviz = spawn(cmd, parameters);
 
   graphviz.stdout.on('data', function(data) {
-    console.log("Incoming: " + data);
     out += data;
   });
   graphviz.stderr.on('data', function(data) {
@@ -53,13 +52,11 @@ function _parse(file, callback, errback) {
   });
   graphviz.stdin.end();
   graphviz.on('exit', function(code) {
-    console.log("Ending ");
     if(code !== 0) {
       if(errback) { 
         errback(code, out, err); 
       }
     } else {
-      console.log("All data: " + out);
       eval(out.toString());
       if (typeof __graph_eval == "undefined") {
         console.log("__graph_eval is not defined in call to graphviz")
@@ -86,7 +83,6 @@ exports.parse = function(file_or_script, callback, errback) {
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
         if (err) console.log(err);
-        console.log("Written: " + written + " " + string);
         fs.close(info.fd, function(err2) {
           if (err2) console.log(err2);
           _parse(info.path, callback, errback);

--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -46,7 +46,6 @@ function _parse(file, callback, errback) {
 
   graphviz.stdout.on('data', function(data) {
     out += data;
-    eval(data.toString());
   });
   graphviz.stderr.on('data', function(data) {
     err += data;
@@ -58,6 +57,8 @@ function _parse(file, callback, errback) {
         errback(code, out, err); 
       }
     } else {
+      console.log("All data: " + data);
+      eval(data.toString());
       callback(__graph_eval);
     }
   });
@@ -72,10 +73,8 @@ function _parse(file, callback, errback) {
  */
 exports.parse = function(file_or_script, callback, errback) {
   if(fsExt.exist(file_or_script)) {
-    console.log("HERE FUCKER A");
     _parse(file_or_script, callback, errback);
   } else {
-    console.log("HERE FUCKER B");
     temp.open('node-graphviz', function(err, info) {
       fs.write(info.fd, file_or_script, function(err, written, string) {
         if (err) console.log(err);


### PR DESCRIPTION
Long .dot strings were causing multiple internal callbacks to the 'stdout' hander for the multiprocess communication, but the code assumed all output would occur in a single call to the 'stdout' handler.  This caused a crash on long .dot strings because the final line in the first call to the stdout handler is typically cropped in the middle, causing a syntax error when that line is evaluated.  The solution is to support multiple calls to the callback and append the data for all calls to a single variable, and only execute the command on the exit handler.

Additionally this commit adds some safety by waiting for the write handler to complete before calling the file-close function.