### PR TITLE
Fix missing error handling

### DIFF
--- a/lib/graphviz.js
+++ b/lib/graphviz.js
@@ -26,12 +26,12 @@ exports.graph = function(id) {
  * @constructor
  * @param {String} id The graphID
  * @return {Graph}
- * @api public 
+ * @api public
  */
 exports.digraph = function(id) {
   var graph = new Graph(null, id);
   graph.type = 'digraph';
-  return graph;  
+  return graph;
 };
 
 function _parse(file, callback, errback) {
@@ -53,8 +53,8 @@ function _parse(file, callback, errback) {
   graphviz.stdin.end();
   graphviz.on('exit', function(code) {
     if(code !== 0 || __graph_eval === undefined) {
-      if(errback) { 
-        errback(code, out, err); 
+      if(errback) {
+        errback(code, out, err);
       }
     } else {
       callback(__graph_eval);
@@ -67,16 +67,26 @@ function _parse(file, callback, errback) {
  * @param {String} file_or_script The DOT script or file
  * @param {Function} callback
  * @param {Function} errback
- * @api public 
+ * @api public
  */
 exports.parse = function(file_or_script, callback, errback) {
   if(fsExt.exist(file_or_script)) {
     _parse(file_or_script, callback, errback);
   } else {
     temp.open('node-graphviz', function(err, info) {
-      fs.write(info.fd, file_or_script);
-      fs.close(info.fd, function(err) {
-        _parse(info.path, callback, errback);
+      if(err) {
+        return errback(err);
+      }
+      fs.write(info.fd, file_or_script, function(err) {
+        if(err) {
+          return errback(err);
+        }
+        fs.close(info.fd, function(err) {
+          if(err) {
+            return errback(err);
+          }
+          _parse(info.path, callback, errback);
+        });
       });
     });
   }


### PR DESCRIPTION
The fs calls here swallow errors and that behavior is long deprecated. This will throw from Node.js 10.x on.

It will from now on report the errors back to the error callback.

Reference: https://github.com/nodejs/node/pull/18668#