### PR TITLE
Remove redundant to_dot call

### DIFF
--- a/lib/deps/graph.js
+++ b/lib/deps/graph.js
@@ -344,8 +344,6 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
 		}
 	}
 	parameters.push( '-T' + type );
-	
-  var dotScript = this.to_dot();
   
   var cmd = this.use;
   if( this.gvPath != '' ) {


### PR DESCRIPTION
I'm guessing this line used to be necessary, but the variable `dotScript` (and the results of this `to_dot` call) are never used.