### PR TITLE
fix: escape graph id

### DIFF
--- a/lib/deps/graph.js
+++ b/lib/deps/graph.js
@@ -259,9 +259,9 @@ Graph.prototype.getEdgeAttribut = function(name) {
 Graph.prototype.to_dot = function() {
   var dotScript = '';
   if (this.relativeGraph == null) {
-    dotScript = this.type + ' ' + this.id + ' {\n';
+    dotScript = this.type + ' "' + this.id + '" {\n';
   } else {
-    dotScript = 'subgraph ' + this.id + ' {\n';
+    dotScript = 'subgraph "' + this.id + '" {\n';
   }
 
   // Graph attributs


### PR DESCRIPTION
without this fix `graphviz.digraph('my-id');` would produce `digraph my-id {` which is invalid, instead it should produce `digraph "my-id" {`