### PR TITLE
Callback even if no error

### DIFF
--- a/lib/deps/graph.js
+++ b/lib/deps/graph.js
@@ -417,6 +417,7 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
           }
         } else {
           if (typeof name_or_callback == 'function') name_or_callback(rendered);
+          else if (errback) errback(code, out, err)
         }
       });
       graphviz.stdin.write(self.to_dot());


### PR DESCRIPTION
Fixes a problem where the process does an 'exit 0' when used in a promise