### PR TITLE
Escape quoted strings labels

### DIFF
--- a/lib/deps/attributs.js
+++ b/lib/deps/attributs.js
@@ -195,7 +195,7 @@ function quoteMe(attr, value) {
   if (value[0] === '!') {
     return '<' + value.substr(1, 1000) + '>';
   } else if (mustBeQuoted(attr)) {
-    return ' "' + value + '"';
+    return ' "' + value.replace(/"/g, "\\\"") + '"';
   } else {
     return value;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphviz",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "Gregoire Lejeune <gregoire.lejeune@free.fr> (http://algorithmique.net/)",
   "description": "Node.js interface to the GraphViz graphing tool",
   "homepage": "http://algorithmique.net/",


### PR DESCRIPTION
To avoid issues when some strings come with double quoted characters, it's required to escape those double quotes to avoid issues in the final `dot` file that also contain double quotes characters generating conflicts.